### PR TITLE
Default behaviour when command called with no opt

### DIFF
--- a/src/main/java/org/jboss/pnc/bacon/cli/Pig.java
+++ b/src/main/java/org/jboss/pnc/bacon/cli/Pig.java
@@ -17,8 +17,13 @@
  */
 package org.jboss.pnc.bacon.cli;
 
+import org.jboss.pnc.bacon.App;
+import org.jboss.pnc.bacon.pig.Build;
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
+
+import java.util.concurrent.Callable;
 
 /**
  * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
@@ -26,7 +31,8 @@ import picocli.CommandLine.Option;
  * Date: 12/13/18
  */
 @Command(name = "pig", mixinStandardHelpOptions = true)
-public class Pig {
+public class Pig extends SubCommandHelper {
+
     @Command(name = "configure", mixinStandardHelpOptions = true)
     public void configure(
             @Option(names = {"-c", "--config"},

--- a/src/main/java/org/jboss/pnc/bacon/cli/Pig.java
+++ b/src/main/java/org/jboss/pnc/bacon/cli/Pig.java
@@ -17,13 +17,8 @@
  */
 package org.jboss.pnc.bacon.cli;
 
-import org.jboss.pnc.bacon.App;
-import org.jboss.pnc.bacon.pig.Build;
-import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
-
-import java.util.concurrent.Callable;
 
 /**
  * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com

--- a/src/main/java/org/jboss/pnc/bacon/cli/Pnc.java
+++ b/src/main/java/org/jboss/pnc/bacon/cli/Pnc.java
@@ -54,5 +54,5 @@ import picocli.CommandLine;
                 Project.class,
                 Repository.class
 })
-public class Pnc {
+public class Pnc extends SubCommandHelper {
 }

--- a/src/main/java/org/jboss/pnc/bacon/cli/SubCommandHelper.java
+++ b/src/main/java/org/jboss/pnc/bacon/cli/SubCommandHelper.java
@@ -17,20 +17,28 @@
  */
 package org.jboss.pnc.bacon.cli;
 
-import picocli.CommandLine.Command;
-import picocli.CommandLine.Parameters;
+import org.jboss.pnc.bacon.App;
+import picocli.CommandLine;
 
-import static org.jboss.pnc.bacon.cli.Constants.NO_VALUE;
+import java.util.concurrent.Callable;
 
 /**
- * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
- * <br>
- * Date: 12/13/18
+ * Class to provide default behaviour when the sub-command is called without any options
+ *
  */
-@Command(name = "da", mixinStandardHelpOptions = true)
-public class Da extends SubCommandHelper {
-    @Command(name = "lookup", mixinStandardHelpOptions = true, description = "lookup available productized artifact version for an artifact")
-    public void lookup(@Parameters(defaultValue = NO_VALUE, description = "groupId:artifactId:version of the artifact to lookup", type = String.class) String gav) {
-        throw new TodoException();
+public class SubCommandHelper implements Runnable {
+
+    @CommandLine.Spec
+    private CommandLine.Model.CommandSpec spec;
+
+    /**
+     * Print the usage message when  the sub-command is called with no options
+     *
+     * @return null
+     */
+    @Override
+    public void run() {
+        spec.commandLine().usage(System.err);
     }
+
 }

--- a/src/main/java/org/jboss/pnc/bacon/cli/pnc/BrewPush.java
+++ b/src/main/java/org/jboss/pnc/bacon/cli/pnc/BrewPush.java
@@ -1,7 +1,8 @@
 package org.jboss.pnc.bacon.cli.pnc;
 
+import org.jboss.pnc.bacon.cli.SubCommandHelper;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "brew-push", mixinStandardHelpOptions = true)
-public class BrewPush {
+public class BrewPush extends SubCommandHelper {
 }

--- a/src/main/java/org/jboss/pnc/bacon/cli/pnc/Build.java
+++ b/src/main/java/org/jboss/pnc/bacon/cli/pnc/Build.java
@@ -1,7 +1,8 @@
 package org.jboss.pnc.bacon.cli.pnc;
 
+import org.jboss.pnc.bacon.cli.SubCommandHelper;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "build", mixinStandardHelpOptions = true)
-public class Build {
+public class Build extends SubCommandHelper {
 }

--- a/src/main/java/org/jboss/pnc/bacon/cli/pnc/BuildConfiguration.java
+++ b/src/main/java/org/jboss/pnc/bacon/cli/pnc/BuildConfiguration.java
@@ -1,9 +1,10 @@
 package org.jboss.pnc.bacon.cli.pnc;
 
+import org.jboss.pnc.bacon.cli.SubCommandHelper;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "build-config", mixinStandardHelpOptions = true)
-public class BuildConfiguration {
+public class BuildConfiguration extends SubCommandHelper {
 
     @CommandLine.Command(name = "create", mixinStandardHelpOptions = true)
     public void create() {

--- a/src/main/java/org/jboss/pnc/bacon/cli/pnc/Environment.java
+++ b/src/main/java/org/jboss/pnc/bacon/cli/pnc/Environment.java
@@ -1,9 +1,10 @@
 package org.jboss.pnc.bacon.cli.pnc;
 
+import org.jboss.pnc.bacon.cli.SubCommandHelper;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "environment", mixinStandardHelpOptions = true)
-public class Environment {
+public class Environment extends SubCommandHelper {
 
     @CommandLine.Command(name = "get", mixinStandardHelpOptions = true)
     public void get() {

--- a/src/main/java/org/jboss/pnc/bacon/cli/pnc/GenerateTools.java
+++ b/src/main/java/org/jboss/pnc/bacon/cli/pnc/GenerateTools.java
@@ -1,10 +1,11 @@
 package org.jboss.pnc.bacon.cli.pnc;
 
+import org.jboss.pnc.bacon.cli.SubCommandHelper;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "generate", mixinStandardHelpOptions = true,
                      description = "Further tools to generate artifacts")
-public class GenerateTools {
+public class GenerateTools extends SubCommandHelper {
 
     @CommandLine.Command(name = "repo-list", mixinStandardHelpOptions = true)
     public void generateRepositoryList() {

--- a/src/main/java/org/jboss/pnc/bacon/cli/pnc/GroupBuild.java
+++ b/src/main/java/org/jboss/pnc/bacon/cli/pnc/GroupBuild.java
@@ -1,7 +1,8 @@
 package org.jboss.pnc.bacon.cli.pnc;
 
+import org.jboss.pnc.bacon.cli.SubCommandHelper;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "group-build", mixinStandardHelpOptions = true)
-public class GroupBuild {
+public class GroupBuild extends SubCommandHelper {
 }

--- a/src/main/java/org/jboss/pnc/bacon/cli/pnc/GroupBuildConfiguration.java
+++ b/src/main/java/org/jboss/pnc/bacon/cli/pnc/GroupBuildConfiguration.java
@@ -1,7 +1,8 @@
 package org.jboss.pnc.bacon.cli.pnc;
 
+import org.jboss.pnc.bacon.cli.SubCommandHelper;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "group-build-config", mixinStandardHelpOptions = true)
-public class GroupBuildConfiguration {
+public class GroupBuildConfiguration extends SubCommandHelper {
 }

--- a/src/main/java/org/jboss/pnc/bacon/cli/pnc/Product.java
+++ b/src/main/java/org/jboss/pnc/bacon/cli/pnc/Product.java
@@ -1,9 +1,10 @@
 package org.jboss.pnc.bacon.cli.pnc;
 
+import org.jboss.pnc.bacon.cli.SubCommandHelper;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "product", mixinStandardHelpOptions = true)
-public class Product {
+public class Product extends SubCommandHelper {
 
     @CommandLine.Command(name = "create", mixinStandardHelpOptions = true)
     public void create() {

--- a/src/main/java/org/jboss/pnc/bacon/cli/pnc/ProductMilestone.java
+++ b/src/main/java/org/jboss/pnc/bacon/cli/pnc/ProductMilestone.java
@@ -1,7 +1,8 @@
 package org.jboss.pnc.bacon.cli.pnc;
 
+import org.jboss.pnc.bacon.cli.SubCommandHelper;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "product-milestone", mixinStandardHelpOptions = true)
-public class ProductMilestone {
+public class ProductMilestone extends SubCommandHelper {
 }

--- a/src/main/java/org/jboss/pnc/bacon/cli/pnc/ProductRelease.java
+++ b/src/main/java/org/jboss/pnc/bacon/cli/pnc/ProductRelease.java
@@ -1,7 +1,8 @@
 package org.jboss.pnc.bacon.cli.pnc;
 
+import org.jboss.pnc.bacon.cli.SubCommandHelper;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "product-release", mixinStandardHelpOptions = true)
-public class ProductRelease {
+public class ProductRelease extends SubCommandHelper {
 }

--- a/src/main/java/org/jboss/pnc/bacon/cli/pnc/ProductVersion.java
+++ b/src/main/java/org/jboss/pnc/bacon/cli/pnc/ProductVersion.java
@@ -1,7 +1,8 @@
 package org.jboss.pnc.bacon.cli.pnc;
 
+import org.jboss.pnc.bacon.cli.SubCommandHelper;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "product-version", mixinStandardHelpOptions = true)
-public class ProductVersion {
+public class ProductVersion extends SubCommandHelper {
 }

--- a/src/main/java/org/jboss/pnc/bacon/cli/pnc/Project.java
+++ b/src/main/java/org/jboss/pnc/bacon/cli/pnc/Project.java
@@ -1,9 +1,10 @@
 package org.jboss.pnc.bacon.cli.pnc;
 
+import org.jboss.pnc.bacon.cli.SubCommandHelper;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "project", mixinStandardHelpOptions = true)
-public class Project {
+public class Project extends SubCommandHelper {
 
     @CommandLine.Command(name = "create", mixinStandardHelpOptions = true)
     public void create() {

--- a/src/main/java/org/jboss/pnc/bacon/cli/pnc/Repository.java
+++ b/src/main/java/org/jboss/pnc/bacon/cli/pnc/Repository.java
@@ -1,9 +1,10 @@
 package org.jboss.pnc.bacon.cli.pnc;
 
+import org.jboss.pnc.bacon.cli.SubCommandHelper;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "repository", mixinStandardHelpOptions = true)
-public class Repository {
+public class Repository extends SubCommandHelper {
 
     @CommandLine.Command(name = "create", mixinStandardHelpOptions = true)
     public void create() {


### PR DESCRIPTION
When the cli is called with no option / subcommand, print the usage as
the default behaviour.

For example:
```
➜  cli git:(add-default-behaviour) ✗ java -jar target/bacon.jar
Usage: java -jar bacon.jar [-hV] [COMMAND]
  -h, --help      Show this help message and exit.
  -V, --version   Print version information and exit.
Commands:
  pig
  pnc
  da

➜  cli git:(add-default-behaviour) ✗ java -jar target/bacon.jar pig
Usage: java -jar bacon.jar pig [-hV] [COMMAND]
  -h, --help      Show this help message and exit.
  -V, --version   Print version information and exit.
Commands:
  build
  configure
  docs
  javadocs
  licenses
  repo
  scripts
  shared-content
  sources
  addons
```