### PR TITLE
Add slf4j / logback

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,25 @@
       <version>3.6.2.Final</version>
     </dependency>
 
+    <!-- log -->
+    <dependency>
+       <groupId>ch.qos.logback</groupId>
+       <artifactId>logback-core</artifactId>
+       <version>1.2.3</version>
+    </dependency>
+
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.2.3</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.25</version>
+    </dependency>
+
     <!--tests-->
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    JBoss, Home of Professional Open Source.
+    Copyright 2017 Red Hat, Inc., and individual contributors
+    as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+
+<!--
+    ******************************************************************************
+    This is the default log settings file. This can be overwritten on the CLI via:
+
+        -Dlogback.configurationFile=/path/to/config.xml
+
+    ******************************************************************************
+-->
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- Make weld logs less noisy: only show WARN messages -->
+    <logger name="org.jboss.weld" level="WARN"/>
+
+    <logger name="org.jboss.logging" level="INFO"/>
+
+    <root level="debug">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION
This commit adds slf4j / logback to the project. JBoss logging (used in
Weld) automatically detects it and use slf4j / logback as the backend
logging solutions instead of JDK logging.

Without slf4j, running a command starts Weld which outputs fairly
useless logs:
```
➜  cli git:(master) ✗ java -jar target/bacon.jar pig build
Jan 01, 2019 11:57:43 AM org.jboss.weld.bootstrap.WeldStartup <clinit>
INFO: WELD-000900: 3.0.5 (Final)
Jan 01, 2019 11:57:43 AM org.jboss.weld.environment.deployment.discovery.DiscoveryStrategyFactory create
INFO: WELD-ENV-000020: Using jandex for bean discovery
Jan 01, 2019 11:57:43 AM org.jboss.weld.bootstrap.WeldStartup startContainer
INFO: WELD-000101: Transactional services not available. Injection of @Inject UserTransaction not available. Transactional observers will be invoked synchronously.
Jan 01, 2019 11:57:43 AM org.jboss.weld.environment.se.WeldContainer fireContainerInitializedEvent
INFO: WELD-ENV-002003: Weld SE container 576b92c4-71e0-4be2-b2a3-6e6b862b61da initialized
Execute build for group: null
did something with config at:build-config.yaml
Weld SE container 576b92c4-71e0-4be2-b2a3-6e6b862b61da shut down by shutdown hook
```

With slf4j + logback, we have the ability to filter the log level of the
various components. By default, the weld logs are set to 'WARN' and
jboss-logging related stuff to 'INFO'. The run below shows the result
when running a command. The Weld 'INFO' messages are hidden:

```
➜  cli git:(master) ✗ java -jar target/bacon.jar pig build
Execute build for group: null
did something with config at:build-config.yaml
Weld SE container a3a62235-eef5-482e-a3af-5c654476232b shut down by shutdown hook
```

This addition will also allow us in the future to fine-tune our logs
when the verbose / quiet option is selected on the CLI options, and
provides us with further configuration changes in the future that can be
easily managed by the logback configuration. A user can also override
the defaults if required.