### PR TITLE
Set the version in picocli to the one in maven

### DIFF
--- a/src/main/java/org/jboss/pnc/bacon/App.java
+++ b/src/main/java/org/jboss/pnc/bacon/App.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.bacon;
 
+import org.jboss.pnc.bacon.cli.Constants;
 import org.jboss.pnc.bacon.cli.Da;
 import org.jboss.pnc.bacon.cli.Pig;
 import org.jboss.pnc.bacon.cli.Pnc;
@@ -33,6 +34,7 @@ import java.util.List;
  */
 @CommandLine.Command(name = "java -jar bacon.jar",
         mixinStandardHelpOptions = true,
+        version = Constants.VERSION + " (" + Constants.COMMIT_ID_SHA + ")",
         subcommands = {Pig.class, Pnc.class, Da.class}
 )
 public class App {


### PR DESCRIPTION
Output when using the '--version' option should look like this:
```
➜  cli git:(use-version) ✗ java -jar target/bacon.jar --version
1.0-SNAPSHOT (a37aa79)
```