### PR TITLE
[NCL-4338] Auth using direct flow for Keycloak

### DIFF
--- a/auth/pom.xml
+++ b/auth/pom.xml
@@ -11,5 +11,48 @@
 
     <artifactId>auth</artifactId>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
 
+        <!-- logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <!-- unirest and family -->
+        <dependency>
+            <groupId>com.mashape.unirest</groupId>
+            <artifactId>unirest-java</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpasyncclient</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpmime</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+
+        <!-- jackson -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+    </dependencies>
 </project>

--- a/auth/src/main/java/org/jboss/pnc/bacon/auth/DirectKeycloakClientImpl.java
+++ b/auth/src/main/java/org/jboss/pnc/bacon/auth/DirectKeycloakClientImpl.java
@@ -1,0 +1,141 @@
+package org.jboss.pnc.bacon.auth;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.mashape.unirest.http.HttpResponse;
+import com.mashape.unirest.http.ObjectMapper;
+import com.mashape.unirest.http.Unirest;
+import lombok.extern.slf4j.Slf4j;
+import org.jboss.pnc.bacon.auth.model.Credential;
+import org.jboss.pnc.bacon.auth.model.KeycloakResponse;
+import org.jboss.pnc.bacon.auth.spi.KeycloakClient;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Date;
+
+/**
+ * Authenticates to Keycloak using direct flow!
+ */
+@Slf4j
+public class DirectKeycloakClientImpl implements KeycloakClient {
+
+    private static void setupUnirest() {
+        // Only one time
+        Unirest.setObjectMapper(new ObjectMapper() {
+            private com.fasterxml.jackson.databind.ObjectMapper jacksonObjectMapper
+                    = new com.fasterxml.jackson.databind.ObjectMapper();
+
+            public <T> T readValue(String value, Class<T> valueType) {
+                try {
+                    return jacksonObjectMapper.readValue(value, valueType);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            public String writeValue(Object value) {
+                try {
+                    return jacksonObjectMapper.writeValueAsString(value);
+                } catch (JsonProcessingException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+    }
+
+    public DirectKeycloakClientImpl() {
+        setupUnirest();
+    }
+
+    /**
+     * TODO: save current token in a file
+     */
+    @Override
+    public Credential getCredential(String keycloakBaseUrl, String realm, String client,
+                                    String username, String password) throws KeycloakClientException {
+
+        String keycloakEndpoint = keycloakEndpoint(keycloakBaseUrl, realm);
+
+        try {
+
+            log.debug("Getting token via username/password");
+
+            HttpResponse<KeycloakResponse> postResponse = Unirest.post(keycloakEndpoint)
+                    .field("grant_type", "password")
+                    .field("client_id", client)
+                    .field("username", username)
+                    .field("password", password)
+                    .asObject(KeycloakResponse.class);
+
+            KeycloakResponse response = postResponse.getBody();
+            Date date = new Date();
+
+            return Credential.builder()
+                    .keycloakBaseUrl(keycloakBaseUrl)
+                    .realm(realm)
+                    .client(client)
+                    .username(username)
+                    .accessToken(response.getAccessToken())
+                    .accessTokenTime(date)
+                    .refreshToken(response.getRefreshToken())
+                    .refreshTokenTime(date)
+                    .build();
+
+        } catch (Exception e) {
+            throw new KeycloakClientException(e);
+        }
+    }
+
+    /**
+     * TODO: save current token in a file
+     */
+    @Override
+    public Credential getCredential(String keycloakBaseUrl, String realm,
+                                    String serviceAccountUsername, String secret) throws KeycloakClientException {
+
+        String keycloakEndpoint = keycloakEndpoint(keycloakBaseUrl, realm);
+
+        try {
+
+            log.debug("Getting token via clientServiceAccountUsername / secret");
+
+            HttpResponse<KeycloakResponse> postResponse = Unirest.post(keycloakEndpoint)
+                    .field("grant_type", "client_credentials")
+                    .field("client_id", serviceAccountUsername)
+                    .field("client_secret", secret)
+                    .asObject(KeycloakResponse.class);
+
+            KeycloakResponse response = postResponse.getBody();
+            Date date = new Date();
+
+            return Credential.builder()
+                    .keycloakBaseUrl(keycloakBaseUrl)
+                    .realm(realm)
+                    .client(serviceAccountUsername)
+                    .accessToken(response.getAccessToken())
+                    .accessTokenTime(date)
+                    .refreshToken(response.getRefreshToken())
+                    .refreshTokenTime(date)
+                    .build();
+
+        } catch (Exception e) {
+            throw new KeycloakClientException(e);
+        }
+    }
+
+    // TODO
+    private void writeCredentialToFile(Credential credential, File file) {
+
+    }
+
+    // TODO
+    private Credential readCredentialFromFile(File file) {
+        return null;
+
+    }
+
+    // TODO
+    private boolean needToRefreshAccessToken(Credential credential, long expiry) {
+        return false;
+    }
+}

--- a/auth/src/main/java/org/jboss/pnc/bacon/auth/KeycloakClientException.java
+++ b/auth/src/main/java/org/jboss/pnc/bacon/auth/KeycloakClientException.java
@@ -1,0 +1,7 @@
+package org.jboss.pnc.bacon.auth;
+
+public class KeycloakClientException extends Exception {
+    public KeycloakClientException(Throwable e) {
+        super(e);
+    }
+}

--- a/auth/src/main/java/org/jboss/pnc/bacon/auth/model/Credential.java
+++ b/auth/src/main/java/org/jboss/pnc/bacon/auth/model/Credential.java
@@ -1,0 +1,27 @@
+package org.jboss.pnc.bacon.auth.model;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.ToString;
+
+import java.util.Date;
+
+@Data
+@Builder
+@ToString
+public class Credential {
+
+    private String keycloakBaseUrl;
+
+    private String realm;
+
+    private String client;
+
+    private String username;
+
+    private String accessToken;
+    private String refreshToken;
+
+    private Date accessTokenTime;
+    private Date refreshTokenTime;
+}

--- a/auth/src/main/java/org/jboss/pnc/bacon/auth/model/KeycloakResponse.java
+++ b/auth/src/main/java/org/jboss/pnc/bacon/auth/model/KeycloakResponse.java
@@ -1,0 +1,16 @@
+package org.jboss.pnc.bacon.auth.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KeycloakResponse {
+
+    @JsonProperty(value = "access_token")
+    private String accessToken;
+
+    @JsonProperty(value = "refresh_token")
+    private String refreshToken;
+}

--- a/auth/src/main/java/org/jboss/pnc/bacon/auth/spi/KeycloakClient.java
+++ b/auth/src/main/java/org/jboss/pnc/bacon/auth/spi/KeycloakClient.java
@@ -1,0 +1,51 @@
+package org.jboss.pnc.bacon.auth.spi;
+
+import org.jboss.pnc.bacon.auth.KeycloakClientException;
+import org.jboss.pnc.bacon.auth.model.Credential;
+
+public interface KeycloakClient {
+
+    /**
+     * Authenticate based on username and password
+     *
+     * @param keycloakBaseUrl
+     * @param realm
+     * @param client
+     * @param username
+     * @param password
+     *
+     * @return Credential object that contains all the information
+     */
+    Credential getCredential(String keycloakBaseUrl, String realm, String client, String username, String password) throws KeycloakClientException;
+
+    /**
+     * Authenticate based on service account and service account secret
+     *
+     * @param keycloakBaseUrl
+     * @param realm
+     * @param serviceAccountUsername
+     * @param secret
+     *
+     * @return Credential object that contains all the information
+     */
+    Credential getCredential(String keycloakBaseUrl, String realm, String serviceAccountUsername, String secret) throws KeycloakClientException;
+
+
+    default String keycloakEndpoint(String keycloakBaseUrl, String realm) {
+
+        String keycloakUrl = keycloakBaseUrl;
+
+        if (!keycloakBaseUrl.endsWith("/")) {
+            keycloakUrl = keycloakBaseUrl + "/";
+        }
+
+        StringBuilder builder = new StringBuilder();
+
+        builder.append(keycloakUrl)
+                .append("auth/realms/")
+                .append(realm)
+                .append("/protocol/openid-connect/token");
+
+        return builder.toString();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,45 @@
                 <version>1.7.25</version>
             </dependency>
 
+            <!-- unirest and family -->
+            <dependency>
+                <groupId>com.mashape.unirest</groupId>
+                <artifactId>unirest-java</artifactId>
+                <version>1.4.9</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+                <version>4.5.7</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpasyncclient</artifactId>
+                <version>4.1.4</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpmime</artifactId>
+                <version>4.5.7</version>
+            </dependency>
+            <dependency>
+                <groupId>org.json</groupId>
+                <artifactId>json</artifactId>
+                <version>20180813</version>
+            </dependency>
+
+            <!-- jackson -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>2.9.8</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>2.9.8</version>
+            </dependency>
+
             <!--tests-->
             <dependency>
                 <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
This commit adds support for authentication to Keycloak using direct
flow. We are also working on using official Keycloak libraries to get
authentication to work via authorization code flow (which is more secure)

It also adds an interface for authentication which can be used for both
direct flow, authorization code flow, and for any other kind of flow in
the future.

## TODO
- Save the access token and the refresh token in a cache file somewhere
  to re-use if still valid.

cc: @matejonnet @michalszynkiewicz @jbartece @geoand 