### PR TITLE
Replace picocli with aesh

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -13,8 +13,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>info.picocli</groupId>
-            <artifactId>picocli</artifactId>
+            <groupId>org.aesh</groupId>
+            <artifactId>aesh</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/common/src/main/java/org/jboss/pnc/bacon/common/SubCommandHelper.java
+++ b/common/src/main/java/org/jboss/pnc/bacon/common/SubCommandHelper.java
@@ -17,25 +17,91 @@
  */
 package org.jboss.pnc.bacon.common;
 
-import picocli.CommandLine;
 
-/**
- * Class to provide default behaviour when the sub-command is called without any options
- *
- */
-public class SubCommandHelper implements Runnable {
+import org.aesh.command.Command;
+import org.aesh.command.CommandException;
+import org.aesh.command.CommandResult;
+import org.aesh.command.GroupCommandDefinition;
+import org.aesh.command.invocation.CommandInvocation;
+import org.aesh.command.option.Option;
+import org.aesh.command.shell.Shell;
 
-    @CommandLine.Spec
-    private CommandLine.Model.CommandSpec spec;
+public class SubCommandHelper implements Command {
 
-    /**
-     * Print the usage message when  the sub-command is called with no options
-     *
-     * @return null
-     */
-    @Override
-    public void run() {
-        spec.commandLine().usage(System.err);
+    @Option(shortName = 'h', overrideRequired = true, hasValue = false, description = "print help")
+    private boolean help = false;
+
+    @Option(shortName = 'V', overrideRequired = true, hasValue = false, description = "print version")
+    private boolean version = false;
+
+
+    private static final String VERSION_OUTPUT = Constants.VERSION + " (" + Constants.COMMIT_ID_SHA + ")";
+
+
+    public boolean printHelpOrVersionIfPresent(CommandInvocation commandInvocation) {
+
+        Shell shell = commandInvocation.getShell();
+
+        boolean activated = false;
+
+        if (help) {
+            shell.writeln(commandInvocation.getHelpInfo());
+            activated = true;
+        }
+
+        if (version) {
+            shell.writeln(VERSION_OUTPUT);
+            activated = true;
+        }
+
+        return activated;
     }
 
+
+    /**
+     * Print help method if a group command is invoked
+     * @param commandInvocation
+     * @return
+     */
+    private boolean printHelpIfNoFinalCommandSelected(CommandInvocation commandInvocation) {
+        GroupCommandDefinition groupCommandDefinition = this.getClass().getAnnotation(GroupCommandDefinition.class);
+
+
+        if (groupCommandDefinition == null) {
+            return false;
+        } else {
+
+            Shell shell = commandInvocation.getShell();
+            shell.writeln(commandInvocation.getHelpInfo());
+            return true;
+        }
+    }
+
+    /**
+     * Default implementation of execute method. For now it just tries to figure out if the user used the '-h' option
+     * and print the help usage if yes.
+     *
+     * If the user used the '-h' option, it'll return CommandResult.SUCCESS, else CommandResult.FAILURE
+     *
+     * @param commandInvocation
+     * @return
+     * @throws CommandException
+     * @throws InterruptedException
+     */
+    @Override
+    public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
+
+        boolean helpNoFinalCommandPrinted = false;
+        boolean helpOrVersionPrinted = printHelpOrVersionIfPresent(commandInvocation);
+
+        if (!helpOrVersionPrinted) {
+            helpNoFinalCommandPrinted = printHelpIfNoFinalCommandSelected(commandInvocation);
+        }
+
+        if (helpOrVersionPrinted || helpNoFinalCommandPrinted) {
+            return CommandResult.SUCCESS;
+        } else {
+            return CommandResult.FAILURE;
+        }
+    }
 }

--- a/da/pom.xml
+++ b/da/pom.xml
@@ -21,8 +21,8 @@
             <artifactId>common</artifactId>
         </dependency>
         <dependency>
-            <groupId>info.picocli</groupId>
-            <artifactId>picocli</artifactId>
+            <groupId>org.aesh</groupId>
+            <artifactId>aesh</artifactId>
         </dependency>
     </dependencies>
 

--- a/da/src/main/java/org/jboss/bacon/da/Da.java
+++ b/da/src/main/java/org/jboss/bacon/da/Da.java
@@ -17,11 +17,10 @@
  */
 package org.jboss.bacon.da;
 
-import org.jboss.pnc.bacon.common.Constants;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.GroupCommandDefinition;
+import org.aesh.command.option.Argument;
 import org.jboss.pnc.bacon.common.SubCommandHelper;
-import org.jboss.pnc.bacon.common.exception.TodoException;
-import picocli.CommandLine.Command;
-import picocli.CommandLine.Parameters;
 
 
 /**
@@ -29,10 +28,16 @@ import picocli.CommandLine.Parameters;
  * <br>
  * Date: 12/13/18
  */
-@Command(name = "da", mixinStandardHelpOptions = true)
+@GroupCommandDefinition(
+        name = "da",
+        description = "Dependency Analysis related commands",
+        groupCommands = {Da.Lookup.class})
 public class Da extends SubCommandHelper {
-    @Command(name = "lookup", mixinStandardHelpOptions = true, description = "lookup available productized artifact version for an artifact")
-    public void lookup(@Parameters(defaultValue = Constants.NO_VALUE, description = "groupId:artifactId:version of the artifact to lookup", type = String.class) String gav) {
-        throw new TodoException();
+
+    @CommandDefinition(name = "lookup", description = "lookup available productized artifact version for an artifact")
+    public class Lookup extends SubCommandHelper {
+
+        @Argument(required = true, description = "groupId:artifactId:version of the artifact to lookup")
+        private String gav = "";
     }
 }

--- a/pig/pom.xml
+++ b/pig/pom.xml
@@ -21,8 +21,8 @@
             <artifactId>common</artifactId>
         </dependency>
         <dependency>
-            <groupId>info.picocli</groupId>
-            <artifactId>picocli</artifactId>
+            <groupId>org.aesh</groupId>
+            <artifactId>aesh</artifactId>
         </dependency>
     </dependencies>
 

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/Pig.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/Pig.java
@@ -17,89 +17,205 @@
  */
 package org.jboss.pnc.bacon.pig;
 
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.CommandException;
+import org.aesh.command.CommandResult;
+import org.aesh.command.GroupCommandDefinition;
+import org.aesh.command.invocation.CommandInvocation;
+import org.aesh.command.option.Option;
 import org.jboss.pnc.bacon.common.SubCommandHelper;
-import picocli.CommandLine.Command;
-import picocli.CommandLine.Option;
+import org.jboss.pnc.bacon.common.exception.TodoException;
 
 /**
  * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
  * <br>
  * Date: 12/13/18
  */
-@Command(name = "pig", mixinStandardHelpOptions = true)
+@GroupCommandDefinition(
+        name = "pig",
+        description = "PfG tool",
+        groupCommands = {
+                Pig.Configure.class,
+                Pig.Build.class,
+                Pig.GenerateRepository.class,
+                Pig.GenerateLicenses.class,
+                Pig.GenerateJavadocs.class,
+                Pig.GenerateSources.class,
+                Pig.GenerateSharedContentAnalysis.class,
+                Pig.GenerateDocuments.class,
+                Pig.GenerateScripts.class,
+                Pig.TriggerAddOns.class
+        })
 public class Pig extends SubCommandHelper {
 
-    @Command(name = "configure", mixinStandardHelpOptions = true)
-    public void configure(
-            @Option(names = {"-c", "--config"},
-                    defaultValue = "build-config.yaml",
-                    description = "location of the configuration file")
-                    String configLocation) {
-        System.out.println("configLocation: " + configLocation);
-        throw new TodoException();
+    @CommandDefinition(name = "configure", description = "Configure")
+    public class Configure extends SubCommandHelper {
+
+        @Option(shortName = 'c',
+                overrideRequired = true,
+                defaultValue = "build-config.yaml",
+                description = "location of configuration file")
+        private String config;
+
+        @Override
+        public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
+
+            CommandResult result = super.execute(commandInvocation);
+
+            if (result == CommandResult.FAILURE) {
+                System.out.println("configLocation: " + config);
+                throw new TodoException();
+
+            }
+            return CommandResult.SUCCESS;
+        }
     }
 
-    @Command(name = "build", mixinStandardHelpOptions = true)
-    public void build(
-            @Option(
-                    names = {"-c", "--config"},
-                    defaultValue = "build-config.yaml",
-                    description = "location of the configuration file") String configLocation,
-            @Option(
-                    names = {"-b", "--build-group"},
-                    description = "id of the group to build. Exactly one of {config, build-group} has to be provided") Integer buildGroupId) {
+    @CommandDefinition(name = "build", description = "Build")
+    public class Build extends SubCommandHelper {
 
+        @Option(shortName = 'c',
+                overrideRequired = true,
+                defaultValue = "build-config.yaml",
+                description = "location of configuration file")
+        private String config;
 
+        @Option(shortName = 'b',
+                overrideRequired = true,
+                description = "id of the group to build. Exactly one of {config, build-group} has to be provided")
+        private Integer buildGroupId;
+
+        @Override
+        public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
+
+            CommandResult result = super.execute(commandInvocation);
+
+            if (result == CommandResult.FAILURE) {
+                System.out.println("configLocation: " + config);
+                throw new TodoException();
+
+            }
+            return CommandResult.SUCCESS;
+        }
     }
 
-    @Command(name = "repo", mixinStandardHelpOptions = true)
-    public void generateRepository() {
-        throw new TodoException();
+    @CommandDefinition(name = "repo", description = "GenerateRepository")
+    public class GenerateRepository extends SubCommandHelper {
+
+        @Override
+        public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
+
+            CommandResult result = super.execute(commandInvocation);
+
+            if (result == CommandResult.FAILURE) {
+                throw new TodoException();
+            }
+            return CommandResult.SUCCESS;
+        }
     }
 
-    @Command(name = "licenses", mixinStandardHelpOptions = true)
-    public void generateLicenses() {
-        throw new TodoException();
+    @CommandDefinition(name = "licenses", description = "GenerateLicenses")
+    public class GenerateLicenses extends SubCommandHelper {
+
+        @Override
+        public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
+
+            CommandResult result = super.execute(commandInvocation);
+
+            if (result == CommandResult.FAILURE) {
+                throw new TodoException();
+            }
+            return CommandResult.SUCCESS;
+        }
     }
 
-    @Command(name = "javadocs", mixinStandardHelpOptions = true)
-    public void generateJavadoc() {
-        throw new TodoException();
+    @CommandDefinition(name = "javadocs", description = "GenerateJavadocs")
+    public class GenerateJavadocs extends SubCommandHelper {
+
+        @Override
+        public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
+
+            CommandResult result = super.execute(commandInvocation);
+
+            if (result == CommandResult.FAILURE) {
+                throw new TodoException();
+            }
+            return CommandResult.SUCCESS;
+        }
     }
 
-    @Command(name = "sources", mixinStandardHelpOptions = true)
-    public void generateSources() {
-        throw new TodoException();
+    @CommandDefinition(name = "sources", description = "GenerateSources")
+    public class GenerateSources extends SubCommandHelper {
+
+        @Override
+        public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
+
+            CommandResult result = super.execute(commandInvocation);
+
+            if (result == CommandResult.FAILURE) {
+                throw new TodoException();
+            }
+            return CommandResult.SUCCESS;
+        }
     }
 
-    @Command(name = "shared-content", mixinStandardHelpOptions = true)
-    public void generateSharedContentAnalysis() {
-        throw new TodoException();
+    @CommandDefinition(name = "shared-content", description = "GenerateSharedContentAnalysis")
+    public class GenerateSharedContentAnalysis extends SubCommandHelper {
+
+        @Override
+        public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
+
+            CommandResult result = super.execute(commandInvocation);
+
+            if (result == CommandResult.FAILURE) {
+                throw new TodoException();
+            }
+            return CommandResult.SUCCESS;
+        }
     }
 
-    @Command(name = "docs", mixinStandardHelpOptions = true)
-    public void generateDocuments() {
-        throw new TodoException();
+    @CommandDefinition(name = "docs", description = "GenerateDocuments")
+    public class GenerateDocuments extends SubCommandHelper {
+
+        @Override
+        public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
+
+            CommandResult result = super.execute(commandInvocation);
+
+            if (result == CommandResult.FAILURE) {
+                throw new TodoException();
+            }
+            return CommandResult.SUCCESS;
+        }
     }
 
-    @Command(name = "addons", mixinStandardHelpOptions = true)
-    public void triggerAddOns() {
-        throw new TodoException();
+    @CommandDefinition(name = "scripts", description = "GenerateScripts")
+    public class GenerateScripts extends SubCommandHelper {
+
+        @Override
+        public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
+
+            CommandResult result = super.execute(commandInvocation);
+
+            if (result == CommandResult.FAILURE) {
+                throw new TodoException();
+            }
+            return CommandResult.SUCCESS;
+        }
     }
 
-    @Command(name = "scripts", mixinStandardHelpOptions = true)
-    public void generateScripts() {
-        throw new TodoException();
-    }
+    @CommandDefinition(name = "addons", description = "Addons")
+    public class TriggerAddOns extends SubCommandHelper {
 
-    /**
-     * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
-     * <br>
-     * Date: 12/13/18
-     */
-    public static class TodoException extends RuntimeException {
-        public TodoException() {
-            super("the method is not implemented yet");
+        @Override
+        public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
+
+            CommandResult result = super.execute(commandInvocation);
+
+            if (result == CommandResult.FAILURE) {
+                throw new TodoException();
+            }
+            return CommandResult.SUCCESS;
         }
     }
 }

--- a/pnc/pom.xml
+++ b/pnc/pom.xml
@@ -21,8 +21,8 @@
             <artifactId>common</artifactId>
         </dependency>
         <dependency>
-            <groupId>info.picocli</groupId>
-            <artifactId>picocli</artifactId>
+            <groupId>org.aesh</groupId>
+            <artifactId>aesh</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/BrewPush.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/BrewPush.java
@@ -17,9 +17,9 @@
  */
 package org.jboss.pnc.bacon.pnc;
 
+import org.aesh.command.GroupCommandDefinition;
 import org.jboss.pnc.bacon.common.SubCommandHelper;
-import picocli.CommandLine;
 
-@CommandLine.Command(name = "brew-push", mixinStandardHelpOptions = true)
+@GroupCommandDefinition(name = "brew-push", description = "brew-push", groupCommands = {})
 public class BrewPush extends SubCommandHelper {
 }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/Build.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/Build.java
@@ -17,9 +17,9 @@
  */
 package org.jboss.pnc.bacon.pnc;
 
+import org.aesh.command.GroupCommandDefinition;
 import org.jboss.pnc.bacon.common.SubCommandHelper;
-import picocli.CommandLine;
 
-@CommandLine.Command(name = "build", mixinStandardHelpOptions = true)
+@GroupCommandDefinition(name = "build", description = "build", groupCommands = {})
 public class Build extends SubCommandHelper {
 }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/BuildConfiguration.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/BuildConfiguration.java
@@ -17,29 +17,40 @@
  */
 package org.jboss.pnc.bacon.pnc;
 
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.GroupCommandDefinition;
 import org.jboss.pnc.bacon.common.SubCommandHelper;
-import picocli.CommandLine;
 
-@CommandLine.Command(name = "build-config", mixinStandardHelpOptions = true)
+@GroupCommandDefinition(
+        name = "brew-config",
+        description = "brew-config",
+        groupCommands = {
+                BuildConfiguration.Create.class,
+                BuildConfiguration.Get.class,
+                BuildConfiguration.List.class,
+                BuildConfiguration.Update.class,
+                BuildConfiguration.Delete.class
+        })
 public class BuildConfiguration extends SubCommandHelper {
 
-    @CommandLine.Command(name = "create", mixinStandardHelpOptions = true)
-    public void create() {
+    @CommandDefinition(name = "create", description = "Create a build configuration")
+    public class Create extends SubCommandHelper {
     }
 
-    @CommandLine.Command(name = "get", mixinStandardHelpOptions = true)
-    public void get() {
+    @CommandDefinition(name = "get", description = "Get build configurations")
+    public class Get extends SubCommandHelper {
     }
 
-    @CommandLine.Command(name = "list", mixinStandardHelpOptions = true)
-    public void list() {
+    @CommandDefinition(name = "list", description = "List build configurations")
+    public class List extends SubCommandHelper {
     }
 
-    @CommandLine.Command(name = "update", mixinStandardHelpOptions = true)
-    public void update() {
+    @CommandDefinition(name = "update", description = "Update a build configuration")
+    public class Update extends SubCommandHelper {
     }
 
-    @CommandLine.Command(name = "delete", mixinStandardHelpOptions = true)
-    public void delete() {
+    @CommandDefinition(name = "delete", description = "Delete a build configuration")
+    public class Delete extends SubCommandHelper {
     }
+
 }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/Environment.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/Environment.java
@@ -17,20 +17,25 @@
  */
 package org.jboss.pnc.bacon.pnc;
 
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.GroupCommandDefinition;
 import org.jboss.pnc.bacon.common.SubCommandHelper;
-import picocli.CommandLine;
 
-@CommandLine.Command(name = "environment", mixinStandardHelpOptions = true)
+@GroupCommandDefinition(
+        name = "environment",
+        description = "environment",
+        groupCommands = {
+                Environment.Get.class,
+                Environment.List.class
+        })
 public class Environment extends SubCommandHelper {
 
-    @CommandLine.Command(name = "get", mixinStandardHelpOptions = true)
-    public void get() {
-
+    @CommandDefinition(name = "get", description = "Get environments")
+    public class Get extends SubCommandHelper {
     }
 
-    @CommandLine.Command(name = "list", mixinStandardHelpOptions = true)
-    public void list() {
-
+    @CommandDefinition(name = "list", description = "List environments")
+    public class List extends SubCommandHelper {
     }
 
 }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/GenerateTools.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/GenerateTools.java
@@ -17,26 +17,31 @@
  */
 package org.jboss.pnc.bacon.pnc;
 
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.GroupCommandDefinition;
 import org.jboss.pnc.bacon.common.SubCommandHelper;
-import picocli.CommandLine;
 
-@CommandLine.Command(name = "generate", mixinStandardHelpOptions = true,
-                     description = "Further tools to generate artifacts")
+@GroupCommandDefinition(
+        name = "generate",
+        description = "Further tools to generate artifacts",
+        groupCommands = {
+                GenerateTools.RepoList.class,
+                GenerateTools.GenerateSourcesZip.class,
+                GenerateTools.MakeMead.class
+        })
 public class GenerateTools extends SubCommandHelper {
 
-    @CommandLine.Command(name = "repo-list", mixinStandardHelpOptions = true)
-    public void generateRepositoryList() {
+    @CommandDefinition(name = "repo-list", description = "Generate a repo-list")
+    public class RepoList extends SubCommandHelper {
         // TODO: should this exist given PIG might implement it also?
     }
 
-    @CommandLine.Command(name = "sources-zip", mixinStandardHelpOptions = true)
-    public void generateSourcesZip() {
+    @CommandDefinition(name = "sources-zip", description = "Generate a sources zip")
+    public class GenerateSourcesZip extends SubCommandHelper {
         // TODO: should this exist given PIG might implement it also?
     }
 
-    @CommandLine.Command(name = "make-mead", mixinStandardHelpOptions = true)
-    public void makeMead() {
-
+    @CommandDefinition(name = "make-mead", description = "make-mead")
+    public class MakeMead extends SubCommandHelper {
     }
-
 }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/GroupBuild.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/GroupBuild.java
@@ -17,9 +17,9 @@
  */
 package org.jboss.pnc.bacon.pnc;
 
+import org.aesh.command.GroupCommandDefinition;
 import org.jboss.pnc.bacon.common.SubCommandHelper;
-import picocli.CommandLine;
 
-@CommandLine.Command(name = "group-build", mixinStandardHelpOptions = true)
+@GroupCommandDefinition(name = "group-build", description = "Group builds", groupCommands = {})
 public class GroupBuild extends SubCommandHelper {
 }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/GroupBuildConfiguration.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/GroupBuildConfiguration.java
@@ -17,9 +17,9 @@
  */
 package org.jboss.pnc.bacon.pnc;
 
+import org.aesh.command.GroupCommandDefinition;
 import org.jboss.pnc.bacon.common.SubCommandHelper;
-import picocli.CommandLine;
 
-@CommandLine.Command(name = "group-build-config", mixinStandardHelpOptions = true)
+@GroupCommandDefinition(name = "group-build-configuration", description = "Group build configuration", groupCommands = {})
 public class GroupBuildConfiguration extends SubCommandHelper {
 }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/Pnc.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/Pnc.java
@@ -17,17 +17,18 @@
  */
 package org.jboss.pnc.bacon.pnc;
 
+import org.aesh.command.GroupCommandDefinition;
 import org.jboss.pnc.bacon.common.SubCommandHelper;
-import picocli.CommandLine;
 
 /**
  * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
  * <br>
  * Date: 12/13/18
  */
-@CommandLine.Command(name = "pnc", mixinStandardHelpOptions = true,
+@GroupCommandDefinition(
+        name = "pnc",
         description = "PNC sub-command",
-        subcommands = {
+        groupCommands = {
                 BrewPush.class,
                 Build.class,
                 BuildConfiguration.class,

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/Product.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/Product.java
@@ -17,25 +17,38 @@
  */
 package org.jboss.pnc.bacon.pnc;
 
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.GroupCommandDefinition;
 import org.jboss.pnc.bacon.common.SubCommandHelper;
-import picocli.CommandLine;
 
-@CommandLine.Command(name = "product", mixinStandardHelpOptions = true)
+@GroupCommandDefinition(
+        name = "product",
+        description = "Product",
+        groupCommands = {
+                Product.Create.class,
+                Product.Get.class,
+                Product.List.class,
+                Product.Update.class
+        })
 public class Product extends SubCommandHelper {
 
-    @CommandLine.Command(name = "create", mixinStandardHelpOptions = true)
-    public void create() {
+
+    @CommandDefinition(name = "create", description = "Create a product")
+    public class Create extends SubCommandHelper {
+
     }
 
-    @CommandLine.Command(name = "get", mixinStandardHelpOptions = true)
-    public void get() {
+    @CommandDefinition(name = "get", description = "Get products")
+    public class Get extends SubCommandHelper {
     }
 
-    @CommandLine.Command(name = "list", mixinStandardHelpOptions = true)
-    public void list() {
+    @CommandDefinition(name = "list", description = "List products")
+    public class List extends SubCommandHelper {
     }
 
-    @CommandLine.Command(name = "update", mixinStandardHelpOptions = true)
-    public void update() {
+    @CommandDefinition(name = "update", description = "Update a product")
+    public class Update extends SubCommandHelper {
     }
+
+
 }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProductMilestone.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProductMilestone.java
@@ -17,9 +17,9 @@
  */
 package org.jboss.pnc.bacon.pnc;
 
+import org.aesh.command.GroupCommandDefinition;
 import org.jboss.pnc.bacon.common.SubCommandHelper;
-import picocli.CommandLine;
 
-@CommandLine.Command(name = "product-milestone", mixinStandardHelpOptions = true)
+@GroupCommandDefinition(name = "product-milestone", description = "Product Milestones", groupCommands = {})
 public class ProductMilestone extends SubCommandHelper {
 }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProductRelease.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProductRelease.java
@@ -17,9 +17,9 @@
  */
 package org.jboss.pnc.bacon.pnc;
 
+import org.aesh.command.GroupCommandDefinition;
 import org.jboss.pnc.bacon.common.SubCommandHelper;
-import picocli.CommandLine;
 
-@CommandLine.Command(name = "product-release", mixinStandardHelpOptions = true)
+@GroupCommandDefinition(name = "product-release", description = "Product Release", groupCommands = {})
 public class ProductRelease extends SubCommandHelper {
 }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProductVersion.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProductVersion.java
@@ -17,9 +17,9 @@
  */
 package org.jboss.pnc.bacon.pnc;
 
+import org.aesh.command.GroupCommandDefinition;
 import org.jboss.pnc.bacon.common.SubCommandHelper;
-import picocli.CommandLine;
 
-@CommandLine.Command(name = "product-version", mixinStandardHelpOptions = true)
+@GroupCommandDefinition(name = "product-version", description = "Product Version", groupCommands = {})
 public class ProductVersion extends SubCommandHelper {
 }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/Project.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/Project.java
@@ -17,30 +17,39 @@
  */
 package org.jboss.pnc.bacon.pnc;
 
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.GroupCommandDefinition;
 import org.jboss.pnc.bacon.common.SubCommandHelper;
-import picocli.CommandLine;
 
-@CommandLine.Command(name = "project", mixinStandardHelpOptions = true)
+@GroupCommandDefinition(
+        name = "project",
+        description = "Project",
+        groupCommands = {
+                Project.Create.class,
+                Project.Get.class,
+                Project.List.class,
+                Project.Update.class,
+                Project.Delete.class
+        })
 public class Project extends SubCommandHelper {
 
-    @CommandLine.Command(name = "create", mixinStandardHelpOptions = true)
-    public void create() {
+    @CommandDefinition(name = "create", description = "Create a project")
+    public class Create extends SubCommandHelper {
     }
 
-    @CommandLine.Command(name = "get", mixinStandardHelpOptions = true)
-    public void get() {
+    @CommandDefinition(name = "get", description = "Get a project")
+    public class Get extends SubCommandHelper {
     }
 
-    @CommandLine.Command(name = "list", mixinStandardHelpOptions = true)
-    public void list() {
+    @CommandDefinition(name = "list", description = "List projects")
+    public class List extends SubCommandHelper {
     }
 
-    @CommandLine.Command(name = "update", mixinStandardHelpOptions = true)
-    public void update() {
+    @CommandDefinition(name = "update", description = "Update a project")
+    public class Update extends SubCommandHelper {
     }
 
-    @CommandLine.Command(name = "delete", mixinStandardHelpOptions = true)
-    public void delete() {
+    @CommandDefinition(name = "delete", description = "Delete a project")
+    public class Delete extends SubCommandHelper {
     }
-
 }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/Repository.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/Repository.java
@@ -17,29 +17,39 @@
  */
 package org.jboss.pnc.bacon.pnc;
 
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.GroupCommandDefinition;
 import org.jboss.pnc.bacon.common.SubCommandHelper;
-import picocli.CommandLine;
 
-@CommandLine.Command(name = "repository", mixinStandardHelpOptions = true)
+@GroupCommandDefinition(
+        name = "repository",
+        description = "Repository",
+        groupCommands = {
+                Repository.Create.class,
+                Repository.Get.class,
+                Repository.List.class,
+                Repository.Update.class,
+                Repository.Delete.class
+        })
 public class Repository extends SubCommandHelper {
 
-    @CommandLine.Command(name = "create", mixinStandardHelpOptions = true)
-    public void create() {
+    @CommandDefinition(name = "create", description = "Create a repository")
+    public class Create extends SubCommandHelper {
     }
 
-    @CommandLine.Command(name = "get", mixinStandardHelpOptions = true)
-    public void get() {
+    @CommandDefinition(name = "get", description = "Get a repository")
+    public class Get extends SubCommandHelper {
     }
 
-    @CommandLine.Command(name = "list", mixinStandardHelpOptions = true)
-    public void list() {
+    @CommandDefinition(name = "list", description = "List repositories")
+    public class List extends SubCommandHelper {
     }
 
-    @CommandLine.Command(name = "update", mixinStandardHelpOptions = true)
-    public void update() {
+    @CommandDefinition(name = "update", description = "Update a repository")
+    public class Update extends SubCommandHelper {
     }
 
-    @CommandLine.Command(name = "delete", mixinStandardHelpOptions = true)
-    public void delete() {
+    @CommandDefinition(name = "delete", description = "Delete a repository")
+    public class Delete extends SubCommandHelper {
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <picocli.version>3.8.2</picocli.version>
+        <aesh.version>2.2</aesh.version>
     </properties>
 
     <dependencyManagement>
@@ -89,11 +89,10 @@
                 <artifactId>rest-api</artifactId>
                 <version>2.0.0-SNAPSHOT</version>
             </dependency>
-
             <dependency>
-                <groupId>info.picocli</groupId>
-                <artifactId>picocli</artifactId>
-                <version>${picocli.version}</version>
+                <groupId>org.aesh</groupId>
+                <artifactId>aesh</artifactId>
+                <version>${aesh.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
The new output with aesh looks like this:

```
➜  cli git:(aesh-impl) ✗ java -jar cli/target/bacon.jar       
Usage: bacon.jar [<options>]
Bacon CLI

Options:
  -h, --help     print help
  -V, --version  print version

bacon.jar commands:
    pnc  PNC sub-command
    da  Dependency Analysis related commands
    pig  PfG tool

➜  cli git:(aesh-impl) ✗ java -jar cli/target/bacon.jar pig 
13:08:40.885 [main] WARN  org.jboss.pnc.bacon.config.Config - Config file: config.yaml has no content
Usage: bacon.jar pig [<options>]
PfG tool

Options:
  -h, --help     print help
  -V, --version  print version

pig commands:
    configure  Configure
    build  Build
    repo  GenerateRepository
    licenses  GenerateLicenses
    javadocs  GenerateJavadocs
    sources  GenerateSources
    shared-content  GenerateSharedContentAnalysis
    docs  GenerateDocuments
    scripts  GenerateScripts
    addons  Addons
```