### PR TITLE
GetSpecific, list for Project,Repository,BC,Environment

### DIFF
--- a/common/src/main/java/org/jboss/pnc/bacon/common/cli/AbstractNotImplementedCommand.java
+++ b/common/src/main/java/org/jboss/pnc/bacon/common/cli/AbstractNotImplementedCommand.java
@@ -1,0 +1,56 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.bacon.common.cli;
+
+
+import lombok.extern.slf4j.Slf4j;
+import org.aesh.command.Command;
+import org.aesh.command.CommandException;
+import org.aesh.command.CommandResult;
+import org.aesh.command.GroupCommandDefinition;
+import org.aesh.command.invocation.CommandInvocation;
+import org.aesh.command.option.Option;
+import org.aesh.command.shell.Shell;
+import org.jboss.pnc.bacon.common.Constants;
+import org.jboss.pnc.client.ClientException;
+import org.jboss.pnc.client.RemoteResourceException;
+
+/**
+ * Abstract command that implements Command
+ *
+ * Provides a default implementation of 'execute' for not implemented commands
+ */
+@Slf4j
+public class AbstractNotImplementedCommand implements Command {
+
+    /**
+     * Default implementation of execute method. Just prints "Not implemented yet!"
+     *
+     *
+     * @param commandInvocation
+     * @return
+     * @throws CommandException
+     * @throws InterruptedException
+     */
+    @Override
+    public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
+
+        log.error("Not implemented yet!");
+        return CommandResult.FAILURE;
+    }
+}

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/BuildConfigurationCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/BuildConfigurationCli.java
@@ -20,10 +20,21 @@ package org.jboss.pnc.bacon.pnc;
 import org.aesh.command.CommandDefinition;
 import org.aesh.command.GroupCommandDefinition;
 import org.jboss.pnc.bacon.common.cli.AbstractCommand;
+import org.jboss.pnc.bacon.common.cli.AbstractGetSpecificCommand;
+import org.jboss.pnc.bacon.common.cli.AbstractListCommand;
+import org.jboss.pnc.bacon.common.cli.AbstractNotImplementedCommand;
+import org.jboss.pnc.bacon.pnc.client.PncClientHelper;
+import org.jboss.pnc.client.BuildConfigurationClient;
+import org.jboss.pnc.client.ClientException;
+import org.jboss.pnc.client.RemoteCollection;
+import org.jboss.pnc.client.RemoteResourceException;
+import org.jboss.pnc.dto.BuildConfiguration;
+
+import java.util.Optional;
 
 @GroupCommandDefinition(
-        name = "brew-config",
-        description = "brew-config",
+        name = "build-config",
+        description = "build-config",
         groupCommands = {
                 BuildConfigurationCli.Create.class,
                 BuildConfigurationCli.Get.class,
@@ -33,24 +44,36 @@ import org.jboss.pnc.bacon.common.cli.AbstractCommand;
         })
 public class BuildConfigurationCli extends AbstractCommand {
 
+    private BuildConfigurationClient client = new BuildConfigurationClient(PncClientHelper.getPncConfiguration());
+
     @CommandDefinition(name = "create", description = "Create a build configuration")
-    public class Create extends AbstractCommand {
+    public class Create extends AbstractNotImplementedCommand {
     }
 
-    @CommandDefinition(name = "get", description = "Get build configurations")
-    public class Get extends AbstractCommand {
+    @CommandDefinition(name = "get", description = "Get build configuration")
+    public class Get extends AbstractGetSpecificCommand<BuildConfiguration> {
+
+        @Override
+        public BuildConfiguration getSpecific(int id) throws ClientException {
+            return client.getSpecific(id);
+        }
     }
 
     @CommandDefinition(name = "list", description = "List build configurations")
-    public class List extends AbstractCommand {
+    public class List extends AbstractListCommand<BuildConfiguration> {
+
+        @Override
+        public RemoteCollection<BuildConfiguration> getAll(String sort, String query) throws RemoteResourceException {
+            return client.getAll(Optional.ofNullable(sort), Optional.ofNullable(query));
+        }
     }
 
     @CommandDefinition(name = "update", description = "Update a build configuration")
-    public class Update extends AbstractCommand {
+    public class Update extends AbstractNotImplementedCommand {
     }
 
     @CommandDefinition(name = "delete", description = "Delete a build configuration")
-    public class Delete extends AbstractCommand {
+    public class Delete extends AbstractNotImplementedCommand {
     }
 
 }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/EnvironmentCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/EnvironmentCli.java
@@ -20,6 +20,16 @@ package org.jboss.pnc.bacon.pnc;
 import org.aesh.command.CommandDefinition;
 import org.aesh.command.GroupCommandDefinition;
 import org.jboss.pnc.bacon.common.cli.AbstractCommand;
+import org.jboss.pnc.bacon.common.cli.AbstractGetSpecificCommand;
+import org.jboss.pnc.bacon.common.cli.AbstractListCommand;
+import org.jboss.pnc.bacon.pnc.client.PncClientHelper;
+import org.jboss.pnc.client.ClientException;
+import org.jboss.pnc.client.EnvironmentClient;
+import org.jboss.pnc.client.RemoteCollection;
+import org.jboss.pnc.client.RemoteResourceException;
+import org.jboss.pnc.dto.Environment;
+
+import java.util.Optional;
 
 @GroupCommandDefinition(
         name = "environment",
@@ -30,12 +40,24 @@ import org.jboss.pnc.bacon.common.cli.AbstractCommand;
         })
 public class EnvironmentCli extends AbstractCommand {
 
-    @CommandDefinition(name = "get", description = "Get environments")
-    public class Get extends AbstractCommand {
+    private EnvironmentClient environmentClient = new EnvironmentClient(PncClientHelper.getPncConfiguration());
+
+    @CommandDefinition(name = "get", description = "Get environment")
+    public class Get extends AbstractGetSpecificCommand<Environment> {
+
+        @Override
+        public Environment getSpecific(int id) throws ClientException {
+            return environmentClient.getSpecific(id);
+        }
     }
 
     @CommandDefinition(name = "list", description = "List environments")
-    public class List extends AbstractCommand {
+    public class List extends AbstractListCommand<Environment> {
+
+        @Override
+        public RemoteCollection<Environment> getAll(String sort, String query) throws RemoteResourceException {
+            return environmentClient.getAll(Optional.ofNullable(sort), Optional.ofNullable(query));
+        }
     }
 
 }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/GenerateToolsCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/GenerateToolsCli.java
@@ -20,6 +20,7 @@ package org.jboss.pnc.bacon.pnc;
 import org.aesh.command.CommandDefinition;
 import org.aesh.command.GroupCommandDefinition;
 import org.jboss.pnc.bacon.common.cli.AbstractCommand;
+import org.jboss.pnc.bacon.common.cli.AbstractNotImplementedCommand;
 
 @GroupCommandDefinition(
         name = "generate",
@@ -32,16 +33,16 @@ import org.jboss.pnc.bacon.common.cli.AbstractCommand;
 public class GenerateToolsCli extends AbstractCommand {
 
     @CommandDefinition(name = "repo-list", description = "Generate a repo-list")
-    public class RepoList extends AbstractCommand {
+    public class RepoList extends AbstractNotImplementedCommand {
         // TODO: should this exist given PIG might implement it also?
     }
 
     @CommandDefinition(name = "sources-zip", description = "Generate a sources zip")
-    public class GenerateSourcesZip extends AbstractCommand {
+    public class GenerateSourcesZip extends AbstractNotImplementedCommand {
         // TODO: should this exist given PIG might implement it also?
     }
 
     @CommandDefinition(name = "make-mead", description = "make-mead")
-    public class MakeMead extends AbstractCommand {
+    public class MakeMead extends AbstractNotImplementedCommand {
     }
 }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProductCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProductCli.java
@@ -22,6 +22,7 @@ import org.aesh.command.GroupCommandDefinition;
 import org.jboss.pnc.bacon.common.cli.AbstractCommand;
 import org.jboss.pnc.bacon.common.cli.AbstractGetSpecificCommand;
 import org.jboss.pnc.bacon.common.cli.AbstractListCommand;
+import org.jboss.pnc.bacon.common.cli.AbstractNotImplementedCommand;
 import org.jboss.pnc.bacon.pnc.client.PncClientHelper;
 import org.jboss.pnc.client.ClientException;
 import org.jboss.pnc.client.ProductClient;
@@ -46,7 +47,7 @@ public class ProductCli extends AbstractCommand {
 
 
     @CommandDefinition(name = "create", description = "Create a product")
-    public class Create extends AbstractCommand {
+    public class Create extends AbstractNotImplementedCommand {
 
     }
 
@@ -70,7 +71,7 @@ public class ProductCli extends AbstractCommand {
     }
 
     @CommandDefinition(name = "update", description = "Update a product")
-    public class Update extends AbstractCommand {
+    public class Update extends AbstractNotImplementedCommand {
     }
 
 

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProjectCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProjectCli.java
@@ -19,7 +19,20 @@ package org.jboss.pnc.bacon.pnc;
 
 import org.aesh.command.CommandDefinition;
 import org.aesh.command.GroupCommandDefinition;
+import org.aesh.command.option.Argument;
 import org.jboss.pnc.bacon.common.cli.AbstractCommand;
+import org.jboss.pnc.bacon.common.cli.AbstractGetSpecificCommand;
+import org.jboss.pnc.bacon.common.cli.AbstractListCommand;
+import org.jboss.pnc.bacon.common.cli.AbstractNotImplementedCommand;
+import org.jboss.pnc.bacon.pnc.client.PncClientHelper;
+import org.jboss.pnc.client.ClientException;
+import org.jboss.pnc.client.ProjectClient;
+import org.jboss.pnc.client.RemoteCollection;
+import org.jboss.pnc.client.RemoteResourceException;
+import org.jboss.pnc.dto.BuildConfiguration;
+import org.jboss.pnc.dto.Project;
+
+import java.util.Optional;
 
 @GroupCommandDefinition(
         name = "project",
@@ -28,28 +41,58 @@ import org.jboss.pnc.bacon.common.cli.AbstractCommand;
                 ProjectCli.Create.class,
                 ProjectCli.Get.class,
                 ProjectCli.List.class,
+                ProjectCli.ListBuildConfigurations.class,
+                ProjectCli.ListBuilds.class,
                 ProjectCli.Update.class,
                 ProjectCli.Delete.class
         })
 public class ProjectCli extends AbstractCommand {
 
+    private ProjectClient client = new ProjectClient(PncClientHelper.getPncConfiguration());
+
     @CommandDefinition(name = "create", description = "Create a project")
-    public class Create extends AbstractCommand {
+    public class Create extends AbstractNotImplementedCommand {
     }
 
     @CommandDefinition(name = "get", description = "Get a project")
-    public class Get extends AbstractCommand {
+    public class Get extends AbstractGetSpecificCommand<Project> {
+
+        @Override
+        public Project getSpecific(int id) throws ClientException {
+            return client.getSpecific(id);
+        }
     }
 
     @CommandDefinition(name = "list", description = "List projects")
-    public class List extends AbstractCommand {
+    public class List extends AbstractListCommand<Project> {
+
+        @Override
+        public RemoteCollection<Project> getAll(String sort, String query) throws RemoteResourceException {
+            return client.getAll(Optional.ofNullable(sort), Optional.ofNullable(query));
+        }
+    }
+
+    @CommandDefinition(name = "get-build-configurations", description = "List build configurations for a project")
+    public class ListBuildConfigurations extends AbstractListCommand<BuildConfiguration> {
+
+        @Argument(required = true, description = "Project id")
+        private int id;
+
+        @Override
+        public RemoteCollection<BuildConfiguration> getAll(String sort, String query) throws RemoteResourceException {
+            return client.getBuildConfigurations(id, Optional.ofNullable(sort), Optional.ofNullable(query));
+        }
+    }
+
+    @CommandDefinition(name = "get-builds", description = "List builds for a project")
+    public class ListBuilds extends AbstractNotImplementedCommand {
     }
 
     @CommandDefinition(name = "update", description = "Update a project")
-    public class Update extends AbstractCommand {
+    public class Update extends AbstractNotImplementedCommand {
     }
 
     @CommandDefinition(name = "delete", description = "Delete a project")
-    public class Delete extends AbstractCommand {
+    public class Delete extends AbstractNotImplementedCommand {
     }
 }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/RepositoryCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/RepositoryCli.java
@@ -19,7 +19,19 @@ package org.jboss.pnc.bacon.pnc;
 
 import org.aesh.command.CommandDefinition;
 import org.aesh.command.GroupCommandDefinition;
+import org.aesh.command.option.Option;
 import org.jboss.pnc.bacon.common.cli.AbstractCommand;
+import org.jboss.pnc.bacon.common.cli.AbstractGetSpecificCommand;
+import org.jboss.pnc.bacon.common.cli.AbstractListCommand;
+import org.jboss.pnc.bacon.common.cli.AbstractNotImplementedCommand;
+import org.jboss.pnc.bacon.pnc.client.PncClientHelper;
+import org.jboss.pnc.client.ClientException;
+import org.jboss.pnc.client.RemoteCollection;
+import org.jboss.pnc.client.RemoteResourceException;
+import org.jboss.pnc.client.SCMRepositoryClient;
+import org.jboss.pnc.dto.SCMRepository;
+
+import java.util.Optional;
 
 @GroupCommandDefinition(
         name = "repository",
@@ -33,23 +45,41 @@ import org.jboss.pnc.bacon.common.cli.AbstractCommand;
         })
 public class RepositoryCli extends AbstractCommand {
 
+    private SCMRepositoryClient client = new SCMRepositoryClient(PncClientHelper.getPncConfiguration());
+
     @CommandDefinition(name = "create", description = "Create a repository")
-    public class Create extends AbstractCommand {
+    public class Create extends AbstractNotImplementedCommand {
     }
 
     @CommandDefinition(name = "get", description = "Get a repository")
-    public class Get extends AbstractCommand {
+    public class Get extends AbstractGetSpecificCommand<SCMRepository> {
+
+        @Override
+        public SCMRepository getSpecific(int id) throws ClientException {
+            return client.getSpecific(id);
+        }
     }
 
     @CommandDefinition(name = "list", description = "List repositories")
-    public class List extends AbstractCommand {
+    public class List extends AbstractListCommand<SCMRepository> {
+
+        @Option(description = "Exact URL to search")
+        private String matchUrl;
+
+        @Option(description = "Part of the URL to search")
+        private String searchUrl;
+
+        @Override
+        public RemoteCollection<SCMRepository> getAll(String sort, String query) throws RemoteResourceException {
+            return client.getAll(matchUrl, searchUrl, Optional.ofNullable(sort), Optional.ofNullable(query));
+        }
     }
 
     @CommandDefinition(name = "update", description = "Update a repository")
-    public class Update extends AbstractCommand {
+    public class Update extends AbstractNotImplementedCommand {
     }
 
     @CommandDefinition(name = "delete", description = "Delete a repository")
-    public class Delete extends AbstractCommand {
+    public class Delete extends AbstractNotImplementedCommand {
     }
 }


### PR DESCRIPTION
This commit also introduces AbstractNotImplementedCommand, whose default
behaviour is to print 'Not Implemented yet!' for not-yet-implemented
commands to warn users.