### PR TITLE
[NCL-4338] Add Keycloak authentication

### DIFF
--- a/common/src/main/java/org/jboss/pnc/bacon/common/Fail.java
+++ b/common/src/main/java/org/jboss/pnc/bacon/common/Fail.java
@@ -1,0 +1,18 @@
+package org.jboss.pnc.bacon.common;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class Fail {
+
+    public static void fail(String reason) {
+        failIfNull(null, reason);
+    }
+
+    public static void failIfNull(Object object, String reason) {
+        if (object == null) {
+            log.error(reason);
+            System.exit(1);
+        }
+    }
+}

--- a/common/src/main/java/org/jboss/pnc/bacon/common/cli/AbstractCommand.java
+++ b/common/src/main/java/org/jboss/pnc/bacon/common/cli/AbstractCommand.java
@@ -42,7 +42,7 @@ import org.jboss.pnc.client.RemoteResourceException;
 public class AbstractCommand implements Command {
 
     public interface SubCommandExecuteInterface {
-        void call() throws RemoteResourceException, ClientException;
+        void call() throws ClientException;
     }
 
     @Option(shortName = 'h', overrideRequired = true, hasValue = false, description = "print help")
@@ -119,7 +119,7 @@ public class AbstractCommand implements Command {
      * @throws CommandException
      * @throws InterruptedException
      */
-    private CommandResult executePrivate(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
+    private CommandResult executePrivate(CommandInvocation commandInvocation) {
         boolean helpNoFinalCommandPrinted = false;
         boolean helpOrVersionPrinted = printHelpOrVersionIfPresent(commandInvocation);
 

--- a/common/src/main/java/org/jboss/pnc/bacon/common/cli/AbstractNotImplementedCommand.java
+++ b/common/src/main/java/org/jboss/pnc/bacon/common/cli/AbstractNotImplementedCommand.java
@@ -22,13 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.aesh.command.Command;
 import org.aesh.command.CommandException;
 import org.aesh.command.CommandResult;
-import org.aesh.command.GroupCommandDefinition;
 import org.aesh.command.invocation.CommandInvocation;
-import org.aesh.command.option.Option;
-import org.aesh.command.shell.Shell;
-import org.jboss.pnc.bacon.common.Constants;
-import org.jboss.pnc.client.ClientException;
-import org.jboss.pnc.client.RemoteResourceException;
 
 /**
  * Abstract command that implements Command

--- a/config.yaml
+++ b/config.yaml
@@ -1,2 +1,38 @@
+# ##############################################################################
+#
+# Config for bacon
+#
+# All urls are the base paths only.
+#
+#     e.g USE http://example.co
+#
+#                 as opposed to:
+#
+#             http://example.com/path
+#
+# ##############################################################################
+
+# ******************************************************************************
+# PNC details
+#
+# ******************************************************************************
 pnc:
     url: ""
+
+# ******************************************************************************
+# Authentication information
+#
+# Uncomment this section if you want to create / update / delete
+# ******************************************************************************
+
+# keycloak:
+#     url: ""
+#     realm: ""
+#     username: ""
+#
+#     # if regular user
+#     clientId: ""
+#     password: ""
+#
+#     # if service account
+#     clientSecret: ""

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -13,6 +13,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jboss.pnc.bacon</groupId>
+            <artifactId>common</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>

--- a/config/src/main/java/org/jboss/pnc/bacon/config/KeycloakConfig.java
+++ b/config/src/main/java/org/jboss/pnc/bacon/config/KeycloakConfig.java
@@ -18,9 +18,12 @@
 package org.jboss.pnc.bacon.config;
 
 import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.jboss.pnc.bacon.common.Fail;
 
 @Data
-public class KeycloakConfig {
+@Slf4j
+public class KeycloakConfig implements Validate {
 
     // Url of Keycloak server
     private String url;
@@ -28,13 +31,36 @@ public class KeycloakConfig {
     // Realm of keycloak
     private String realm;
 
-    // Client to use to authenticate. Can be a regular client or a client service account
+    // Client to use to authenticate. Only used for regular users, not for service accounts
     private String clientId;
 
-    // username and password: used if client is a regular client
+    // username: can be a regular user or service account
     private String username;
+
+    // password: used if regular user
     private String password;
 
-    // clientSecret used if client is a client service account
+    // clientSecret used if user is a service account
     private String clientSecret;
+
+    public boolean isServiceAccount() {
+        return clientSecret != null && !clientSecret.isEmpty();
+    }
+
+    public void validate() {
+
+        Validate.validateUrl(url, "Keycloak");
+
+        Fail.failIfNull(realm, "The Keycloak realm has to be specified");
+        Fail.failIfNull(username, "The username in the Keycloak config has to be specified");
+
+        if (isServiceAccount()) {
+            log.debug("clientSecret is in the config file! Assuming this is a service account");
+        } else {
+            log.debug("clientSecret is not specified in the config file! Assuming this is a regular user");
+            Fail.failIfNull(clientId, "You need to specify the client id for your regular account in the config file");
+            Fail.failIfNull(password, "You need to specify the password for your regular account in the config file");
+        }
+
+    }
 }

--- a/config/src/main/java/org/jboss/pnc/bacon/config/PncConfig.java
+++ b/config/src/main/java/org/jboss/pnc/bacon/config/PncConfig.java
@@ -25,6 +25,11 @@ import lombok.Data;
  * Date: 12/17/18
  */
 @Data
-public class PncConfig {
+public class PncConfig implements Validate {
+
     private String url;
+
+    public void validate() {
+        Validate.validateUrl(url, "PNC");
+    }
 }

--- a/config/src/main/java/org/jboss/pnc/bacon/config/Validate.java
+++ b/config/src/main/java/org/jboss/pnc/bacon/config/Validate.java
@@ -1,0 +1,36 @@
+package org.jboss.pnc.bacon.config;
+
+import org.jboss.pnc.bacon.common.Fail;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public interface Validate {
+
+   /**
+    * WARNING: If validation fails, the method may stop the application
+    */
+   void validate();
+
+    /**
+     * WARNING: If validation fails, the method will stop the application
+     *
+     * Checks if url is null or empty and has the proper format
+     */
+   static void validateUrl(String url, String kind) {
+
+        if (url == null || url.isEmpty()) {
+            Fail.fail(kind + " Url is not specified in the config file!");
+        }
+
+        try {
+            URI uri = new URI(url);
+
+            Fail.failIfNull(uri.getScheme(), "You need to specify the protocol of the " + kind + " URL in the config file");
+            Fail.failIfNull(uri.getHost(), "You need to specify the host of the " + kind + " URL in the config file");
+
+        } catch (URISyntaxException e) {
+            Fail.fail("Could not parse the " + kind + " Url at all! " + e.getMessage());
+        }
+   }
+}

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/OSCheck.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/OSCheck.java
@@ -27,7 +27,7 @@ public class OSCheck {
      */
     public enum OSType {
         Windows, MacOS, Linux, Other
-    };
+    }
 
     // cached result of OS detection
     protected static OSType detectedOS;

--- a/pnc/pom.xml
+++ b/pnc/pom.xml
@@ -14,6 +14,10 @@
     <dependencies>
         <dependency>
             <groupId>org.jboss.pnc.bacon</groupId>
+            <artifactId>auth</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.pnc.bacon</groupId>
             <artifactId>config</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
The Keycloak authentication automatically kicks in when the config file
has the keycloak section in it.

The authentication is currently being done via the direct flow.

A helper method in `PncClientHelper#authRequired` is provided to *stop*
the application if it did not authenticate to Keycloak.

The format of the keycloak config is specified in the config.yaml