### PR TITLE
Delay call to config until required

### DIFF
--- a/cli/src/main/java/org/jboss/pnc/bacon/cli/App.java
+++ b/cli/src/main/java/org/jboss/pnc/bacon/cli/App.java
@@ -25,11 +25,8 @@ import org.aesh.command.impl.registry.AeshCommandRegistryBuilder;
 import org.aesh.command.registry.CommandRegistry;
 import org.jboss.bacon.da.Da;
 import org.jboss.pnc.bacon.common.cli.AbstractCommand;
-import org.jboss.pnc.bacon.config.Config;
 import org.jboss.pnc.bacon.pig.Pig;
 import org.jboss.pnc.bacon.pnc.Pnc;
-
-import java.io.IOException;
 
 /**
  * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
@@ -56,7 +53,6 @@ public class App extends AbstractCommand {
                 .commandRegistry(registry)
                 .build();
 
-
        try {
            runtime.executeCommand(buildCLIOutput(args));
        } catch (RuntimeException ex) {
@@ -72,7 +68,7 @@ public class App extends AbstractCommand {
        }
     }
 
-    private String buildCLIOutput(String[] args) {
+    private static String buildCLIOutput(String[] args) {
         StringBuilder builder = new StringBuilder();
 
         builder.append("bacon.jar ");
@@ -87,21 +83,7 @@ public class App extends AbstractCommand {
 
     public static void main(String[] args) throws Exception {
 
-        initializeConfig();
-
         App app = new App();
         app.run(args);
-    }
-
-    private static void initializeConfig() {
-        String configLocation = System.getProperty("config", "config.yaml");
-        try {
-            Config.initialize(configLocation);
-        } catch (IOException e) {
-            System.err.println("Configuration file not found. " +
-                    "Please create a config file and either name it 'config.yaml' and put it in the working directory" +
-                    " or specify it with -Dconfig");
-            System.exit(1);
-        }
     }
 }

--- a/common/src/main/java/org/jboss/pnc/bacon/common/cli/AbstractCommand.java
+++ b/common/src/main/java/org/jboss/pnc/bacon/common/cli/AbstractCommand.java
@@ -27,7 +27,6 @@ import org.aesh.command.invocation.CommandInvocation;
 import org.aesh.command.option.Option;
 import org.aesh.command.shell.Shell;
 import org.jboss.pnc.client.ClientException;
-import org.jboss.pnc.client.RemoteResourceException;
 
 /**
  * Abstract command that implements Command

--- a/config/src/main/java/org/jboss/pnc/bacon/config/Config.java
+++ b/config/src/main/java/org/jboss/pnc/bacon/config/Config.java
@@ -46,6 +46,19 @@ public class Config {
     private static Config instance;
 
     public static Config instance() {
+
+        if (instance == null) {
+
+            String configLocation = System.getProperty("config", "config.yaml");
+
+            try {
+                Config.initialize(configLocation);
+            } catch (IOException e) {
+                System.err.println("Configuration file not found. " +
+                        "Please create a config file and either name it 'config.yaml' and put it in the working directory" +
+                        " or specify it with -Dconfig");
+            }
+        }
         return instance;
     }
 

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ArtifactCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ArtifactCli.java
@@ -24,14 +24,21 @@ import org.jboss.pnc.dto.Artifact;
         })
 public class ArtifactCli extends AbstractCommand {
 
-    private static ArtifactClient client = new ArtifactClient(PncClientHelper.getPncConfiguration());
+    private static ArtifactClient clientCache;
+
+    private static ArtifactClient getClient() {
+        if (clientCache == null) {
+            clientCache = new ArtifactClient(PncClientHelper.getPncConfiguration());
+        }
+        return clientCache;
+    }
 
     @CommandDefinition(name = "get", description = "Get artifact")
     public class Get extends AbstractGetSpecificCommand<Artifact> {
 
         @Override
         public Artifact getSpecific(int id) throws ClientException {
-            return client.getSpecific(id);
+            return getClient().getSpecific(id);
         }
     }
 
@@ -56,7 +63,7 @@ public class ArtifactCli extends AbstractCommand {
                 if (md5 == null && sha1 == null && sha256 == null) {
                     log.error("You need to use at least one hash option!");
                 } else {
-                    for (Artifact artifact : client.getAll(sha256, md5, sha1)) {
+                    for (Artifact artifact : getClient().getAll(sha256, md5, sha1)) {
                         // TODO: print in yaml or json
                         System.out.println(artifact);
                     }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/BuildCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/BuildCli.java
@@ -40,7 +40,14 @@ import java.nio.file.Paths;
 public class BuildCli extends AbstractCommand {
 
 
-    private BuildClient client = new BuildClient(PncClientHelper.getPncConfiguration());
+    private static BuildClient clientCache;
+
+    private static BuildClient getClient() {
+        if (clientCache == null) {
+            clientCache = new BuildClient(PncClientHelper.getPncConfiguration());
+        }
+        return clientCache;
+    }
 
     @CommandDefinition(name = "download-sources", description = "Download SCM sources used for the build")
     public class DownloadSources extends AbstractCommand {
@@ -56,7 +63,7 @@ public class BuildCli extends AbstractCommand {
 
                 String filename = id + "-sources.tar.gz";
 
-                Response response = client.getInternalScmArchiveLink(id);
+                Response response = getClient().getInternalScmArchiveLink(id);
 
                 InputStream in = (InputStream) response.getEntity();
 

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/BuildConfigCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/BuildConfigCli.java
@@ -44,7 +44,14 @@ import java.util.Optional;
         })
 public class BuildConfigCli extends AbstractCommand {
 
-    private BuildConfigurationClient client = new BuildConfigurationClient(PncClientHelper.getPncConfiguration());
+    private static BuildConfigurationClient clientCache;
+
+    private static BuildConfigurationClient getClient() {
+        if (clientCache == null) {
+            clientCache = new BuildConfigurationClient(PncClientHelper.getPncConfiguration());
+        }
+        return clientCache;
+    }
 
     @CommandDefinition(name = "create", description = "Create a build configuration")
     public class Create extends AbstractNotImplementedCommand {
@@ -55,7 +62,7 @@ public class BuildConfigCli extends AbstractCommand {
 
         @Override
         public BuildConfiguration getSpecific(int id) throws ClientException {
-            return client.getSpecific(id);
+            return getClient().getSpecific(id);
         }
     }
 
@@ -64,7 +71,7 @@ public class BuildConfigCli extends AbstractCommand {
 
         @Override
         public RemoteCollection<BuildConfiguration> getAll(String sort, String query) throws RemoteResourceException {
-            return client.getAll(Optional.ofNullable(sort), Optional.ofNullable(query));
+            return getClient().getAll(Optional.ofNullable(sort), Optional.ofNullable(query));
         }
     }
 

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/EnvironmentCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/EnvironmentCli.java
@@ -40,14 +40,21 @@ import java.util.Optional;
         })
 public class EnvironmentCli extends AbstractCommand {
 
-    private EnvironmentClient environmentClient = new EnvironmentClient(PncClientHelper.getPncConfiguration());
+    private static EnvironmentClient clientCache;
+
+    private static EnvironmentClient getClient() {
+        if (clientCache == null) {
+            clientCache = new EnvironmentClient(PncClientHelper.getPncConfiguration());
+        }
+        return clientCache;
+    }
 
     @CommandDefinition(name = "get", description = "Get environment")
     public class Get extends AbstractGetSpecificCommand<Environment> {
 
         @Override
         public Environment getSpecific(int id) throws ClientException {
-            return environmentClient.getSpecific(id);
+            return getClient().getSpecific(id);
         }
     }
 
@@ -56,7 +63,7 @@ public class EnvironmentCli extends AbstractCommand {
 
         @Override
         public RemoteCollection<Environment> getAll(String sort, String query) throws RemoteResourceException {
-            return environmentClient.getAll(Optional.ofNullable(sort), Optional.ofNullable(query));
+            return getClient().getAll(Optional.ofNullable(sort), Optional.ofNullable(query));
         }
     }
 

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProductCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProductCli.java
@@ -43,8 +43,14 @@ import java.util.Optional;
         })
 public class ProductCli extends AbstractCommand {
 
-    private static ProductClient client = new ProductClient(PncClientHelper.getPncConfiguration());
+    private static ProductClient clientCache;
 
+    private static ProductClient getClient() {
+        if (clientCache == null) {
+            clientCache = new ProductClient(PncClientHelper.getPncConfiguration());
+        }
+        return clientCache;
+    }
 
     @CommandDefinition(name = "create", description = "Create a product")
     public class Create extends AbstractNotImplementedCommand {
@@ -56,7 +62,7 @@ public class ProductCli extends AbstractCommand {
 
         @Override
         public Product getSpecific(int id) throws ClientException {
-            return client.getSpecific(id);
+            return getClient().getSpecific(id);
         }
     }
 
@@ -66,13 +72,11 @@ public class ProductCli extends AbstractCommand {
         @Override
         public RemoteCollection<Product> getAll(String sort, String query) throws RemoteResourceException {
 
-            return client.getAll(Optional.ofNullable(sort), Optional.ofNullable(query));
+            return getClient().getAll(Optional.ofNullable(sort), Optional.ofNullable(query));
         }
     }
 
     @CommandDefinition(name = "update", description = "Update a product")
     public class Update extends AbstractNotImplementedCommand {
     }
-
-
 }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProductMilestoneCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProductMilestoneCli.java
@@ -48,7 +48,14 @@ import java.util.Optional;
         })
 public class ProductMilestoneCli extends AbstractCommand {
 
-    private static ProductMilestoneClient client = new ProductMilestoneClient(PncClientHelper.getPncConfiguration());
+    private static ProductMilestoneClient clientCache;
+
+    private static ProductMilestoneClient getClient() {
+        if (clientCache == null) {
+            clientCache = new ProductMilestoneClient(PncClientHelper.getPncConfiguration());
+        }
+        return clientCache;
+    }
 
     @CommandDefinition(name = "cancel-milestone-close", description = "Cancel milestone close")
     public class CancelMilestoneClose extends AbstractCommand {
@@ -59,7 +66,7 @@ public class ProductMilestoneCli extends AbstractCommand {
         @Override
         public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
 
-            return super.executeHelper(commandInvocation, () -> client.cancelMilestoneClose(id));
+            return super.executeHelper(commandInvocation, () -> getClient().cancelMilestoneClose(id));
         }
     }
 
@@ -68,7 +75,7 @@ public class ProductMilestoneCli extends AbstractCommand {
 
         @Override
         public ProductMilestone getSpecific(int id) throws ClientException {
-            return client.getSpecific(id);
+            return getClient().getSpecific(id);
         }
     }
 
@@ -81,7 +88,7 @@ public class ProductMilestoneCli extends AbstractCommand {
         @Override
         public RemoteCollection<Build> getAll(String sort, String query) throws RemoteResourceException {
             // TODO: figure out what to do with BuildsFilter
-            return client.getBuilds(id, null, Optional.ofNullable(sort), Optional.of(query));
+            return getClient().getBuilds(id, null, Optional.ofNullable(sort), Optional.of(query));
         }
     }
 

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProductReleaseCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProductReleaseCli.java
@@ -39,15 +39,21 @@ import org.jboss.pnc.enums.SupportLevel;
         })
 public class ProductReleaseCli extends AbstractCommand {
 
-    private static ProductReleaseClient client = new ProductReleaseClient(PncClientHelper.getPncConfiguration());
+    private static ProductReleaseClient clientCache;
 
+    private static ProductReleaseClient getClient() {
+        if (clientCache == null) {
+           clientCache = new ProductReleaseClient(PncClientHelper.getPncConfiguration());
+        }
+        return clientCache;
+    }
 
     @CommandDefinition(name = "get", description = "Get product release")
     public class Get extends AbstractGetSpecificCommand<ProductRelease> {
 
         @Override
         public ProductRelease getSpecific(int id) throws ClientException {
-            return client.getSpecific(id);
+            return getClient().getSpecific(id);
         }
     }
 
@@ -59,7 +65,7 @@ public class ProductReleaseCli extends AbstractCommand {
 
             return super.executeHelper(commandInvocation, () -> {
                 // TODO: YAML or JSON format?
-                for (SupportLevel supportLevel : client.getAllSupportLevel()) {
+                for (SupportLevel supportLevel : getClient().getAllSupportLevel()) {
                     System.out.println(supportLevel);
                 }
             });

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProductVersionCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProductVersionCli.java
@@ -48,14 +48,22 @@ import java.util.Optional;
         })
 public class ProductVersionCli extends AbstractCommand {
 
-    private static ProductVersionClient client = new ProductVersionClient(PncClientHelper.getPncConfiguration());
+    private static ProductVersionClient clientCache;
+
+    private static ProductVersionClient getClient() {
+
+        if (clientCache == null) {
+            clientCache = new ProductVersionClient(PncClientHelper.getPncConfiguration());
+        }
+        return clientCache;
+    }
 
     @CommandDefinition(name = "get", description = "Get product version")
     public class Get extends AbstractGetSpecificCommand<ProductVersion> {
 
         @Override
         public ProductVersion getSpecific(int id) throws ClientException {
-            return client.getSpecific(id);
+            return getClient().getSpecific(id);
         }
     }
 
@@ -70,7 +78,7 @@ public class ProductVersionCli extends AbstractCommand {
         public RemoteCollection<BuildConfiguration> getAll(String sort, String query)
                 throws RemoteResourceException {
 
-            return client.getBuildConfigurations(id, Optional.ofNullable(sort), Optional.ofNullable(query));
+            return getClient().getBuildConfigurations(id, Optional.ofNullable(sort), Optional.ofNullable(query));
         }
     }
 
@@ -84,7 +92,7 @@ public class ProductVersionCli extends AbstractCommand {
         @Override
         public RemoteCollection<GroupConfiguration> getAll(String sort, String query) throws RemoteResourceException {
 
-            return client.getGroupConfigurations(id, Optional.ofNullable(sort), Optional.ofNullable(query));
+            return getClient().getGroupConfigurations(id, Optional.ofNullable(sort), Optional.ofNullable(query));
         }
     }
 
@@ -99,7 +107,7 @@ public class ProductVersionCli extends AbstractCommand {
         public RemoteCollection<org.jboss.pnc.dto.ProductMilestone> getAll(String sort, String query)
                 throws RemoteResourceException {
 
-            return client.getMilestones(id, Optional.ofNullable(sort), Optional.ofNullable(query));
+            return getClient().getMilestones(id, Optional.ofNullable(sort), Optional.ofNullable(query));
         }
     }
 
@@ -114,7 +122,7 @@ public class ProductVersionCli extends AbstractCommand {
         public RemoteCollection<ProductRelease> getAll(String sort, String query)
                 throws RemoteResourceException {
 
-            return client.getReleases(id, Optional.ofNullable(sort), Optional.ofNullable(query));
+            return getClient().getReleases(id, Optional.ofNullable(sort), Optional.ofNullable(query));
         }
     }
 }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProjectCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProjectCli.java
@@ -48,7 +48,14 @@ import java.util.Optional;
         })
 public class ProjectCli extends AbstractCommand {
 
-    private ProjectClient client = new ProjectClient(PncClientHelper.getPncConfiguration());
+    private static ProjectClient clientCache;
+
+    private static ProjectClient getClient() {
+        if (clientCache == null) {
+            clientCache = new ProjectClient(PncClientHelper.getPncConfiguration());
+        }
+        return clientCache;
+    }
 
     @CommandDefinition(name = "create", description = "Create a project")
     public class Create extends AbstractNotImplementedCommand {
@@ -59,7 +66,7 @@ public class ProjectCli extends AbstractCommand {
 
         @Override
         public Project getSpecific(int id) throws ClientException {
-            return client.getSpecific(id);
+            return getClient().getSpecific(id);
         }
     }
 
@@ -68,7 +75,7 @@ public class ProjectCli extends AbstractCommand {
 
         @Override
         public RemoteCollection<Project> getAll(String sort, String query) throws RemoteResourceException {
-            return client.getAll(Optional.ofNullable(sort), Optional.ofNullable(query));
+            return getClient().getAll(Optional.ofNullable(sort), Optional.ofNullable(query));
         }
     }
 
@@ -80,7 +87,7 @@ public class ProjectCli extends AbstractCommand {
 
         @Override
         public RemoteCollection<BuildConfiguration> getAll(String sort, String query) throws RemoteResourceException {
-            return client.getBuildConfigurations(id, Optional.ofNullable(sort), Optional.ofNullable(query));
+            return getClient().getBuildConfigurations(id, Optional.ofNullable(sort), Optional.ofNullable(query));
         }
     }
 

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ScmRepositoryCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ScmRepositoryCli.java
@@ -45,7 +45,14 @@ import java.util.Optional;
         })
 public class ScmRepositoryCli extends AbstractCommand {
 
-    private SCMRepositoryClient client = new SCMRepositoryClient(PncClientHelper.getPncConfiguration());
+    private static SCMRepositoryClient clientCache;
+
+    private static SCMRepositoryClient getClient() {
+        if (clientCache == null) {
+            clientCache = new SCMRepositoryClient(PncClientHelper.getPncConfiguration());
+        }
+        return clientCache;
+    }
 
     @CommandDefinition(name = "create", description = "Create a repository")
     public class Create extends AbstractNotImplementedCommand {
@@ -56,7 +63,7 @@ public class ScmRepositoryCli extends AbstractCommand {
 
         @Override
         public SCMRepository getSpecific(int id) throws ClientException {
-            return client.getSpecific(id);
+            return getClient().getSpecific(id);
         }
     }
 
@@ -71,7 +78,7 @@ public class ScmRepositoryCli extends AbstractCommand {
 
         @Override
         public RemoteCollection<SCMRepository> getAll(String sort, String query) throws RemoteResourceException {
-            return client.getAll(matchUrl, searchUrl, Optional.ofNullable(sort), Optional.ofNullable(query));
+            return getClient().getAll(matchUrl, searchUrl, Optional.ofNullable(sort), Optional.ofNullable(query));
         }
     }
 


### PR DESCRIPTION
This allows users to run '--help' or '--version' without having to have
a valid configuration file

This should resolve: https://github.com/project-ncl/cli/issues/38